### PR TITLE
CC-26202 Added additional validation to form fields.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": ">=8.0",
         "spryker/country": "^3.0.0",
         "spryker/glossary": "^3.0.0",
+        "spryker/gui": "^3.48.0",
         "spryker/kernel": "^3.46.0",
         "spryker/locale": "^3.0.0",
         "spryker/merchant": "^3.0.0",

--- a/dependency.json
+++ b/dependency.json
@@ -1,5 +1,6 @@
 {
     "include": {
+        "spryker/gui": "Provides `sanitize_xss` functionality.",
         "spryker/zed-ui": "If you want to use Zed Ui layout templates.",
         "spryker/merchant-profile": "Plugins provide merchant profile functionality.",
         "spryker/transfer": "Provides transfer objects definition with `::get*OrFail()` functionality."

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/BusinessInfoMerchantProfileForm.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/BusinessInfoMerchantProfileForm.php
@@ -293,6 +293,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
             'label' => static::LABEL_EMAIL,
             'required' => true,
             'constraints' => $this->getEmailFieldConstraints($this->getCurrentIdFromFormData($builder)),
+            'sanitize_xss' => true,
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/BusinessInfoMerchantProfileForm.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/BusinessInfoMerchantProfileForm.php
@@ -198,6 +198,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
             ],
             'required' => true,
             'property_path' => 'merchantProfile.contactPersonFirstName',
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -219,6 +220,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
             ],
             'required' => true,
             'property_path' => 'merchantProfile.contactPersonLastName',
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -236,6 +238,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
             'constraints' => $this->getTextFieldConstraints(),
             'required' => false,
             'property_path' => 'merchantProfile.contactPersonRole',
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -254,6 +257,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
                 $this->createNotBlankConstraint(),
                 $this->createLengthConstraint(),
             ],
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -272,6 +276,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
             'constraints' => [
                 new Length(['max' => 255]),
             ],
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -333,6 +338,7 @@ class BusinessInfoMerchantProfileForm extends AbstractType
             'constraints' => $this->getTextFieldConstraints(),
             'required' => false,
             'property_path' => 'merchantProfile.contactPersonPhone',
+            'sanitize_xss' => true,
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileAddressFormType.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileAddressFormType.php
@@ -180,6 +180,7 @@ class MerchantProfileAddressFormType extends AbstractType
             'constraints' => [
                 new Length(['max' => 255]),
             ],
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -198,6 +199,7 @@ class MerchantProfileAddressFormType extends AbstractType
             'constraints' => [
                 new Length(['max' => 10]),
             ],
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -216,6 +218,7 @@ class MerchantProfileAddressFormType extends AbstractType
             'constraints' => [
                 new Length(['max' => 255]),
             ],
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -232,6 +235,7 @@ class MerchantProfileAddressFormType extends AbstractType
             'label' => static::LABEL_ADDRESS_2,
             'required' => false,
             'constraints' => [new Length(['max' => 255])],
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -248,6 +252,7 @@ class MerchantProfileAddressFormType extends AbstractType
             'label' => static::LABEL_ADDRESS_3,
             'required' => false,
             'constraints' => [new Length(['max' => 255])],
+            'sanitize_xss' => true,
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileGlossary/MerchantProfileGlossaryAttributeValuesFormType.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileGlossary/MerchantProfileGlossaryAttributeValuesFormType.php
@@ -164,7 +164,6 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
             'constraints' => $this->getTextareaConstrains(),
             'sanitize_xss' => true,
             'allowed_attributes' => ['style'],
-            'allowed_html_tags' => ['iframe'],
         ]);
 
         return $this;
@@ -184,8 +183,6 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
             ],
             'required' => false,
             'sanitize_xss' => true,
-            'allowed_attributes' => ['style'],
-            'allowed_html_tags' => ['iframe'],
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileGlossary/MerchantProfileGlossaryAttributeValuesFormType.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileGlossary/MerchantProfileGlossaryAttributeValuesFormType.php
@@ -162,6 +162,9 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
             ],
             'required' => false,
             'constraints' => $this->getTextareaConstrains(),
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
+            'allowed_html_tags' => ['iframe'],
         ]);
 
         return $this;
@@ -180,6 +183,9 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
                 'placeholder' => static::PLACEHOLDER_BANNER_URL_GLOSSARY,
             ],
             'required' => false,
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
+            'allowed_html_tags' => ['iframe'],
         ]);
 
         return $this;
@@ -199,6 +205,8 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
             ],
             'required' => false,
             'constraints' => $this->getTextareaConstrains(),
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
         ]);
 
         return $this;
@@ -219,6 +227,8 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
                 'placeholder' => static::PLACEHOLDER_TERMS_CONDITIONS_GLOSSARY,
             ],
             'constraints' => $this->getTextareaConstrains(),
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
         ]);
 
         return $this;
@@ -239,6 +249,8 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
                 'placeholder' => static::PLACEHOLDER_CANCELLATION_POLICY_GLOSSARY,
             ],
             'constraints' => $this->getTextareaConstrains(),
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
         ]);
 
         return $this;
@@ -259,6 +271,8 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
                 'placeholder' => static::PLACEHOLDER_IMPRINT_GLOSSARY,
             ],
             'constraints' => $this->getTextareaConstrains(),
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
         ]);
 
         return $this;
@@ -279,6 +293,8 @@ class MerchantProfileGlossaryAttributeValuesFormType extends AbstractType
                 'placeholder' => static::PLACEHOLDER_DATA_PRIVACY_GLOSSARY,
             ],
             'constraints' => $this->getTextareaConstrains(),
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileUrlCollection/MerchantProfileUrlCollectionFormType.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/MerchantProfileUrlCollection/MerchantProfileUrlCollectionFormType.php
@@ -101,6 +101,7 @@ class MerchantProfileUrlCollectionFormType extends AbstractType
                     'message' => 'Invalid path provided. "Space" and "\" character is not allowed.',
                 ]),
             ],
+            'sanitize_xss' => true,
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/OnlineProfileMerchantProfileForm.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/OnlineProfileMerchantProfileForm.php
@@ -194,6 +194,7 @@ class OnlineProfileMerchantProfileForm extends AbstractType
             'constraints' => $this->getTextFieldConstraints(),
             'required' => false,
             'property_path' => 'merchantProfile.publicPhone',
+            'sanitize_xss' => true,
         ]);
 
         return $this;
@@ -214,6 +215,7 @@ class OnlineProfileMerchantProfileForm extends AbstractType
                 'placeholder' => static::PLACEHOLDER_LOGO_URL,
             ],
             'property_path' => 'merchantProfile.logoUrl',
+            'sanitize_xss' => true,
         ]);
 
         return $this;

--- a/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/OnlineProfileMerchantProfileForm.php
+++ b/src/Spryker/Zed/MerchantProfileMerchantPortalGui/Communication/Form/OnlineProfileMerchantProfileForm.php
@@ -177,6 +177,7 @@ class OnlineProfileMerchantProfileForm extends AbstractType
                 new Length(['max' => 255]),
             ],
             'property_path' => 'merchantProfile.publicEmail',
+            'sanitize_xss' => true,
         ]);
 
         return $this;


### PR DESCRIPTION
* Branch: backport/1.8.0
* Ticket: https://spryker.atlassian.net/browse/CC-26202
* Version: 1.8.0
#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   MerchantProfileMerchantPortalGui  | minor                 |                       |

-----------------------------------------

#### Module MerchantProfileMerchantPortalGui

##### Change log

Fixes

- Adjusted `BusinessInfoMerchantProfileForm` to sanitize the `contact_person_first_name`,  `contact_person_first_name`, `contact_person_last_name`, `contact_person_role`, `name`, `registration_number`, `contact_person_phone`, `email` fields.
- Adjusted `MerchantProfileAddressFormType` to sanitize the `city`,  `zip_code`, `address1`, `address2`, `address3` fields.
- Adjusted `MerchantProfileGlossaryAttributeValuesFormType` to sanitize the `descriptionGlossaryKey`,  `bannerUrlGlossaryKey`, `deliveryTimeGlossaryKey`, `termsConditionsGlossaryKey`, `cancellationPolicyGlossaryKey`, `imprintGlossaryKey`,
`dataPrivacyGlossaryKey` fields.
- Adjusted `MerchantProfileUrlCollectionFormType` to sanitize the `url` field.
- Adjusted `OnlineProfileMerchantProfileForm` to sanitize the `public_phone`,  `logo_url`, `public_email` fields.
- Impacted `ProfileController::updateMerchant()` with these changes.
- Impacted `ProfileController::indexAction()` with these changes.
- Added `Gui` module to dependencies.